### PR TITLE
Add support for tabs + groups

### DIFF
--- a/src/Field/Group/EditorTab.php
+++ b/src/Field/Group/EditorTab.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Group;
+
+use Torr\Storyblok\Field\Definition\AbstractField;
+use Torr\Storyblok\Field\FieldDefinitionInterface;
+use Torr\Storyblok\Field\FieldType;
+use Torr\Storyblok\Field\NestedFieldDefinitionInterface;
+use Torr\Storyblok\Transformer\DataTransformer;
+use Torr\Storyblok\Validator\DataValidator;
+use Torr\Storyblok\Visitor\DataVisitorInterface;
+
+final class EditorTab extends AbstractField implements NestedFieldDefinitionInterface
+{
+	public function __construct (
+		string $label,
+		/** @var array<string, FieldDefinitionInterface> $fields */
+		private readonly array $fields,
+	)
+	{
+		parent::__construct($label);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getInternalStoryblokType () : FieldType
+	{
+		return FieldType::Tab;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function toManagementApiData (int $position, ) : array
+	{
+		return \array_replace(
+			parent::toManagementApiData($position),
+			[
+				"keys" => \array_keys($this->fields),
+			],
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getNestedFields () : array
+	{
+		return $this->fields;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function validateData (DataValidator $validator, array $path, mixed $data, ) : void
+	{
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function transformValue (
+		mixed $data,
+		DataTransformer $dataTransformer,
+		?DataVisitorInterface $dataVisitor = null,
+	) : mixed
+	{
+		return $data;
+	}
+}

--- a/src/Field/Group/FieldGroup.php
+++ b/src/Field/Group/FieldGroup.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Group;
+
+use Torr\Storyblok\Field\Definition\AbstractField;
+use Torr\Storyblok\Field\FieldDefinitionInterface;
+use Torr\Storyblok\Field\FieldType;
+use Torr\Storyblok\Field\NestedFieldDefinitionInterface;
+use Torr\Storyblok\Transformer\DataTransformer;
+use Torr\Storyblok\Validator\DataValidator;
+use Torr\Storyblok\Visitor\DataVisitorInterface;
+
+final class FieldGroup extends AbstractField implements NestedFieldDefinitionInterface
+{
+	public function __construct (
+		string $label,
+		/** @var array<string, FieldDefinitionInterface> $fields */
+		private readonly array $fields,
+	)
+	{
+		parent::__construct($label);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getInternalStoryblokType () : FieldType
+	{
+		return FieldType::Section;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function toManagementApiData (int $position, ) : array
+	{
+		return \array_replace(
+			parent::toManagementApiData($position),
+			[
+				"keys" => \array_keys($this->fields),
+			],
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getNestedFields () : array
+	{
+		return $this->fields;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function validateData (DataValidator $validator, array $path, mixed $data, ) : void
+	{
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function transformValue (
+		mixed $data,
+		DataTransformer $dataTransformer,
+		?DataVisitorInterface $dataVisitor = null,
+	) : mixed
+	{
+		return $data;
+	}
+}

--- a/src/Field/NestedFieldDefinitionInterface.php
+++ b/src/Field/NestedFieldDefinitionInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field;
+
+interface NestedFieldDefinitionInterface
+{
+	/**
+	 * Returns the nested fields
+	 *
+	 * @return FieldDefinitionInterface[]
+	 */
+	public function getNestedFields () : array;
+}


### PR DESCRIPTION
Usage:


```php
/**
 * @inheritDoc
 */
protected function configureFields () : array
{
	return [
		"rte" => new RichTextField(
			"RTE",
			filterComponents: new ComponentsWithTags("ohai"),
		),
		"group1" => new FieldGroup("Group 1", [
			"test" => new TextField("Text"),
			"number" => new NumberField("Numbör"),
		]),
		"tab1" => new EditorTab("Other tab", [
			"test" => new TextField("abc"),
		]),
	];
}
```