### PR TITLE
Add missing `NotNull` validation constraint to require fields that check for `new Type(…)` + Fix `BloksField` validating entire API data instead of nested

### DIFF
--- a/src/Field/Definition/AbstractField.php
+++ b/src/Field/Definition/AbstractField.php
@@ -16,7 +16,7 @@ abstract class AbstractField implements FieldDefinitionInterface
 {
 	private ?bool $canSync = false;
 	private ?bool $isPreviewField = false;
-	private bool $required = false;
+	protected bool $required = false;
 	private ?string $regexp = null;
 	private bool $translatable = false;
 	private ?string $description = null;

--- a/src/Field/Definition/AbstractField.php
+++ b/src/Field/Definition/AbstractField.php
@@ -21,6 +21,7 @@ abstract class AbstractField implements FieldDefinitionInterface
 	private bool $translatable = false;
 	private ?string $description = null;
 	private bool $descriptionAsTooltip = false;
+	protected bool $allowMissingData = false;
 
 	public function __construct (
 		private readonly string $label,
@@ -58,15 +59,21 @@ abstract class AbstractField implements FieldDefinitionInterface
 	/**
 	 * Enables validation for this field
 	 *
+	 * @param bool $allowMissingData This parameter should only be set to `true` when the given field has been added to
+	 *                               a component after it has already been published and used. Storyblok does not send
+	 *                               default values on existing Stories when a new field has been added.
+	 *
 	 * @return $this
 	 */
 	public function enableValidation (
 		bool $required = true,
 		?string $regexp = null,
+		bool $allowMissingData = false,
 	) : static
 	{
 		$this->required = $required;
 		$this->regexp = $regexp;
+		$this->allowMissingData = $allowMissingData;
 
 		return $this;
 	}

--- a/src/Field/Definition/AssetField.php
+++ b/src/Field/Definition/AssetField.php
@@ -75,7 +75,7 @@ final class AssetField extends AbstractField
 			new Type("bool"),
 		];
 
-		if (!$this->allowMissingData)
+		if (!$this->allowMissingData && $this->required)
 		{
 			$idConstraints[] = new NotNull();
 			$fileNameConstraints[] = new NotNull();
@@ -87,7 +87,7 @@ final class AssetField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("array"),
 				// required fields
 				new Collection(

--- a/src/Field/Definition/AssetField.php
+++ b/src/Field/Definition/AssetField.php
@@ -65,24 +65,35 @@ final class AssetField extends AbstractField
 	 */
 	public function validateData (ComponentContext $context, array $contentPath, mixed $data) : void
 	{
+		$idConstraints = [
+			new Type("string"),
+		];
+		$fileNameConstraints = [
+			new Type("string"),
+		];
+		$isExternalUrlConstraints = [
+			new Type("bool"),
+		];
+
+		if (!$this->allowMissingData)
+		{
+			$idConstraints[] = new NotNull();
+			$fileNameConstraints[] = new NotNull();
+			$isExternalUrlConstraints[] = new NotNull();
+		}
+
 		$context->ensureDataIsValid(
 			$contentPath,
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				new Type("array"),
 				// required fields
 				new Collection(
 					fields: [
-						"id" => [
-							new NotNull(),
-							new Type("int"),
-						],
-						"filename" => [
-							new NotNull(),
-							new Type("string"),
-						],
+						"id" => $idConstraints,
+						"filename" => $fileNameConstraints,
 						"fieldtype" => [
 							new IdenticalTo("asset"),
 						],
@@ -111,10 +122,7 @@ final class AssetField extends AbstractField
 						"copyright" => [
 							new Type("string"),
 						],
-						"is_external_url" => [
-							new NotNull(),
-							new Type("bool"),
-						],
+						"is_external_url" => $isExternalUrlConstraints,
 					],
 					allowExtraFields: true,
 					allowMissingFields: true,

--- a/src/Field/Definition/AssetField.php
+++ b/src/Field/Definition/AssetField.php
@@ -70,14 +70,17 @@ final class AssetField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("array"),
 				// required fields
 				new Collection(
 					fields: [
 						"id" => [
+							new NotNull(),
 							new Type("int"),
 						],
 						"filename" => [
+							new NotNull(),
 							new Type("string"),
 						],
 						"fieldtype" => [

--- a/src/Field/Definition/BloksField.php
+++ b/src/Field/Definition/BloksField.php
@@ -81,6 +81,7 @@ final class BloksField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("array"),
 				new All(
 					constraints: [

--- a/src/Field/Definition/BloksField.php
+++ b/src/Field/Definition/BloksField.php
@@ -110,7 +110,7 @@ final class BloksField extends AbstractField
 				$component = $context->getComponentByKey($componentData["component"]);
 				$component->validateData(
 					$context,
-					$data,
+					$componentData,
 					$contentPath,
 				);
 			}

--- a/src/Field/Definition/BloksField.php
+++ b/src/Field/Definition/BloksField.php
@@ -81,7 +81,7 @@ final class BloksField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("array"),
 				new All(
 					constraints: [

--- a/src/Field/Definition/DateTimeField.php
+++ b/src/Field/Definition/DateTimeField.php
@@ -56,7 +56,7 @@ final class DateTimeField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("string"),
 				new DateTime(self::DATE_TIME_FORMAT),
 			],

--- a/src/Field/Definition/DateTimeField.php
+++ b/src/Field/Definition/DateTimeField.php
@@ -3,6 +3,7 @@
 namespace Torr\Storyblok\Field\Definition;
 
 use Symfony\Component\Validator\Constraints\DateTime;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Field\FieldType;
@@ -55,6 +56,7 @@ final class DateTimeField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("string"),
 				new DateTime(self::DATE_TIME_FORMAT),
 			],

--- a/src/Field/Definition/LinkField.php
+++ b/src/Field/Definition/LinkField.php
@@ -72,6 +72,7 @@ final class LinkField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("array"),
 				new Collection(
 					fields: [
@@ -108,6 +109,7 @@ final class LinkField extends AbstractField
 				new Collection(
 					fields: [
 						"anchor" => [
+							new NotNull(),
 							new Type("string"),
 						],
 					],

--- a/src/Field/Definition/LinkField.php
+++ b/src/Field/Definition/LinkField.php
@@ -72,7 +72,7 @@ final class LinkField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("array"),
 				new Collection(
 					fields: [

--- a/src/Field/Definition/LinkField.php
+++ b/src/Field/Definition/LinkField.php
@@ -72,7 +72,7 @@ final class LinkField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				new Type("array"),
 				new Collection(
 					fields: [

--- a/src/Field/Definition/MarkdownField.php
+++ b/src/Field/Definition/MarkdownField.php
@@ -57,7 +57,7 @@ final class MarkdownField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				new Type("string"),
 			],
 		);

--- a/src/Field/Definition/MarkdownField.php
+++ b/src/Field/Definition/MarkdownField.php
@@ -57,7 +57,7 @@ final class MarkdownField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("string"),
 			],
 		);

--- a/src/Field/Definition/MarkdownField.php
+++ b/src/Field/Definition/MarkdownField.php
@@ -2,6 +2,7 @@
 
 namespace Torr\Storyblok\Field\Definition;
 
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Field\FieldType;
@@ -56,6 +57,7 @@ final class MarkdownField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("string"),
 			],
 		);

--- a/src/Field/Definition/NumberField.php
+++ b/src/Field/Definition/NumberField.php
@@ -37,7 +37,7 @@ final class NumberField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				// numbers are always passed as strings
 				new Type("string"),
 				new Regex("~^\\d+(\\.\\d+)?$~"),

--- a/src/Field/Definition/NumberField.php
+++ b/src/Field/Definition/NumberField.php
@@ -37,7 +37,7 @@ final class NumberField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				// numbers are always passed as strings
 				new Type("string"),
 				new Regex("~^\\d+(\\.\\d+)?$~"),

--- a/src/Field/Definition/NumberField.php
+++ b/src/Field/Definition/NumberField.php
@@ -2,6 +2,7 @@
 
 namespace Torr\Storyblok\Field\Definition;
 
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Context\ComponentContext;
@@ -36,6 +37,7 @@ final class NumberField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				// numbers are always passed as strings
 				new Type("string"),
 				new Regex("~^\\d+(\\.\\d+)?$~"),

--- a/src/Field/Definition/RichTextField.php
+++ b/src/Field/Definition/RichTextField.php
@@ -2,6 +2,7 @@
 
 namespace Torr\Storyblok\Field\Definition;
 
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Component\Reference\ComponentsWithTags;
 use Torr\Storyblok\Context\ComponentContext;
@@ -89,6 +90,7 @@ final class RichTextField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("array"),
 			],
 		);

--- a/src/Field/Definition/RichTextField.php
+++ b/src/Field/Definition/RichTextField.php
@@ -90,7 +90,7 @@ final class RichTextField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				new Type("array"),
 			],
 		);

--- a/src/Field/Definition/RichTextField.php
+++ b/src/Field/Definition/RichTextField.php
@@ -90,7 +90,7 @@ final class RichTextField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("array"),
 			],
 		);

--- a/src/Field/Definition/TextField.php
+++ b/src/Field/Definition/TextField.php
@@ -2,6 +2,7 @@
 
 namespace Torr\Storyblok\Field\Definition;
 
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Field\FieldType;
@@ -57,6 +58,7 @@ final class TextField extends AbstractField
 			$this,
 			$data,
 			[
+				new NotNull(),
 				new Type("string"),
 				// We can't validate the length here, as it is not guaranteed if you add
 				// the max-length after content was added.

--- a/src/Field/Definition/TextField.php
+++ b/src/Field/Definition/TextField.php
@@ -58,7 +58,7 @@ final class TextField extends AbstractField
 			$this,
 			$data,
 			[
-				new NotNull(),
+				!$this->allowMissingData ? new NotNull() : null,
 				new Type("string"),
 				// We can't validate the length here, as it is not guaranteed if you add
 				// the max-length after content was added.

--- a/src/Field/Definition/TextField.php
+++ b/src/Field/Definition/TextField.php
@@ -58,7 +58,7 @@ final class TextField extends AbstractField
 			$this,
 			$data,
 			[
-				!$this->allowMissingData ? new NotNull() : null,
+				!$this->allowMissingData && $this->required ? new NotNull() : null,
 				new Type("string"),
 				// We can't validate the length here, as it is not guaranteed if you add
 				// the max-length after content was added.


### PR DESCRIPTION
Since the `TypeValidator` doesn't enforce `null` values (https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Validator/Constraints/TypeValidator.php#L61-L63), we need to add a `NotNull` constraint to all required fields that have a `new Type()` constraint in order to make sure we're not getting bogus data.