### PR TITLE
Add 80ms delay between each component sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"psr/log": "^3.0",
 		"symfony/console": "^6.1",
 		"symfony/http-client": "^6.1",
+		"symfony/rate-limiter": "^6.2",
 		"symfony/validator": "^6.1"
 	},
 	"require-dev": {

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -14,7 +14,7 @@ final class StoryblokBundleExtension extends ConfigurableBundleExtension impleme
 	public function prepend (ContainerBuilder $container) : void
 	{
 		/**
-		 * @link https://www.storyblok.com/docs/technical-limits
+		 * @see https://www.storyblok.com/docs/technical-limits
 		 */
 		$container->prependExtensionConfig("framework", [
 			"rate_limiter" => [

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Torr\BundleHelpers\Bundle\ConfigurableBundleExtension;
+
+final class StoryblokBundleExtension extends ConfigurableBundleExtension implements PrependExtensionInterface
+{
+	/**
+	 * @inheritDoc
+	 */
+	public function prepend (ContainerBuilder $container) : void
+	{
+		$container->prependExtensionConfig("framework", [
+			"rate_limiter" => [
+				"storyblok_management" => [
+					"policy" => "fixed_window",
+					"limit" => 6,
+					"interval" => "1 second",
+				],
+				"storyblok_content_delivery" => [
+					"policy" => "fixed_window",
+					"limit" => 1000,
+					"interval" => "1 second",
+				],
+			],
+		]);
+	}
+}

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -20,7 +20,10 @@ final class StoryblokBundleExtension extends ConfigurableBundleExtension impleme
 			"rate_limiter" => [
 				"storyblok_management" => [
 					"policy" => "fixed_window",
-					"limit" => 6,
+					// the limit is 3 for free plans. It is likely that a debug implementation uses a free dummy space in Storyblok
+					"limit" => $container->getParameter("kernel.debug")
+						? 3
+						: 6,
 					"interval" => "1 second",
 				],
 				"storyblok_content_delivery" => [

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -13,6 +13,9 @@ final class StoryblokBundleExtension extends ConfigurableBundleExtension impleme
 	 */
 	public function prepend (ContainerBuilder $container) : void
 	{
+		/**
+		 * @link https://www.storyblok.com/docs/technical-limits
+		 */
 		$container->prependExtensionConfig("framework", [
 			"rate_limiter" => [
 				"storyblok_management" => [

--- a/src/Manager/Sync/ComponentSync.php
+++ b/src/Manager/Sync/ComponentSync.php
@@ -67,8 +67,6 @@ final class ComponentSync
 			$io->write("Syncing {$key} ");
 			$performedAction = $this->managementApi->syncComponent($config->config, $config->groupLabel);
 			$io->writeln(\sprintf("%s <fg=green>✓</>", $performedAction->value));
-
-			\usleep(80000);
 		}
 	}
 

--- a/src/Manager/Sync/ComponentSync.php
+++ b/src/Manager/Sync/ComponentSync.php
@@ -67,6 +67,8 @@ final class ComponentSync
 			$io->write("Syncing {$key} ");
 			$performedAction = $this->managementApi->syncComponent($config->config, $config->groupLabel);
 			$io->writeln(\sprintf("%s <fg=green>✓</>", $performedAction->value));
+
+			\usleep(80000);
 		}
 	}
 

--- a/src/TorrStoryblokBundle.php
+++ b/src/TorrStoryblokBundle.php
@@ -5,10 +5,10 @@ namespace Torr\Storyblok;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Torr\BundleHelpers\Bundle\ConfigurableBundleExtension;
 use Torr\Storyblok\Component\AbstractComponent;
 use Torr\Storyblok\Config\StoryblokConfig;
 use Torr\Storyblok\DependencyInjection\StoryblokBundleConfiguration;
+use Torr\Storyblok\DependencyInjection\StoryblokBundleExtension;
 
 final class TorrStoryblokBundle extends Bundle
 {
@@ -17,7 +17,7 @@ final class TorrStoryblokBundle extends Bundle
 	 */
 	public function getContainerExtension () : ExtensionInterface
 	{
-		return new ConfigurableBundleExtension(
+		return new StoryblokBundleExtension(
 			$this,
 			new StoryblokBundleConfiguration(),
 			static function (array $config, ContainerBuilder $container) : void


### PR DESCRIPTION
This prevents flooding the Management API and preventing the HTTP 429 error