### PR TITLE
Mark nested fields as required if parent field becomes required

### DIFF
--- a/src/Field/Group/AbstractGroupingElement.php
+++ b/src/Field/Group/AbstractGroupingElement.php
@@ -31,12 +31,17 @@ abstract class AbstractGroupingElement extends AbstractField implements NestedFi
 	 */
 	public function toManagementApiData (int $position, ) : array
 	{
-		return \array_replace(
+		$data = \array_replace(
 			parent::toManagementApiData($position),
 			[
 				"keys" => \array_keys($this->fieldCollection->getRootFields()),
 			],
 		);
+
+		unset($data["required"]);
+		unset($data["regexp"]);
+
+		return $data;
 	}
 
 	/**

--- a/src/Field/Group/AbstractGroupingElement.php
+++ b/src/Field/Group/AbstractGroupingElement.php
@@ -114,8 +114,6 @@ abstract class AbstractGroupingElement extends AbstractField implements NestedFi
 		bool $allowMissingData = false,
 	) : static
 	{
-		parent::enableValidation($required, $regexp, $allowMissingData);
-
 		foreach ($this->fieldCollection->getRootFields() as $rootField)
 		{
 			if ($rootField instanceof AbstractField)

--- a/src/Field/Group/AbstractGroupingElement.php
+++ b/src/Field/Group/AbstractGroupingElement.php
@@ -38,8 +38,8 @@ abstract class AbstractGroupingElement extends AbstractField implements NestedFi
 			],
 		);
 
-		unset($data["required"]);
-		unset($data["regexp"]);
+		unset($data["required"], $data["regexp"]);
+
 
 		return $data;
 	}

--- a/src/Field/Group/AbstractGroupingElement.php
+++ b/src/Field/Group/AbstractGroupingElement.php
@@ -104,4 +104,26 @@ abstract class AbstractGroupingElement extends AbstractField implements NestedFi
 			$dataVisitor,
 		);
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function enableValidation (
+		bool $required = true,
+		?string $regexp = null,
+		bool $allowMissingData = false,
+	) : static
+	{
+		parent::enableValidation($required, $regexp, $allowMissingData);
+
+		foreach ($this->fieldCollection->getRootFields() as $rootField)
+		{
+			if ($rootField instanceof AbstractField)
+			{
+				$rootField->enableValidation($required, $regexp, $allowMissingData);
+			}
+		}
+
+		return $this;
+	}
 }


### PR DESCRIPTION
This may introduce a potential problem in that we won't be able to have optional fields within a `FieldGroup` or an `EditorTab` — but at this point we don't have a hard use-case for that so we can fix it as soon as it becomes one.