### PR TITLE
Add proper support for handling multi-select Choices

### DIFF
--- a/src/Field/Choices/ChoicesInterface.php
+++ b/src/Field/Choices/ChoicesInterface.php
@@ -15,7 +15,7 @@ interface ChoicesInterface
 	 * Validates the given data.
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool;
 
@@ -24,6 +24,6 @@ interface ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed;
 }

--- a/src/Field/Choices/DatasourceChoices.php
+++ b/src/Field/Choices/DatasourceChoices.php
@@ -32,7 +32,7 @@ final class DatasourceChoices implements ChoicesInterface
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{
@@ -44,7 +44,7 @@ final class DatasourceChoices implements ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed
 	{
 		return $data;

--- a/src/Field/Choices/EnumChoices.php
+++ b/src/Field/Choices/EnumChoices.php
@@ -50,10 +50,21 @@ class EnumChoices extends StaticChoices
 	/**
 	 * @inheritDoc
 	 *
-	 * @return T
+	 * @return T|T[]
 	 */
-	public function transformData (ComponentContext $context, int|string $data) : BackedEnumChoiceInterface
+	public function transformData (
+		ComponentContext $context,
+		array|int|string $data,
+	) : BackedEnumChoiceInterface|array
 	{
+		if (\is_array($data))
+		{
+			return \array_map(
+				fn ($value) => $this->enumType::from($value),
+				$data
+			);
+		}
+
 		return $this->enumType::from($data);
 	}
 
@@ -62,10 +73,20 @@ class EnumChoices extends StaticChoices
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{
-		return null !== $this->enumType::tryFrom($data);
+		$values = \is_array($data) ? $data : [$data];
+
+		foreach ($values as $value)
+		{
+			if (null === $this->enumType::tryFrom($value))
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/src/Field/Choices/EnumChoices.php
+++ b/src/Field/Choices/EnumChoices.php
@@ -61,7 +61,7 @@ class EnumChoices extends StaticChoices
 		{
 			return \array_map(
 				fn ($value) => $this->enumType::from($value),
-				$data
+				$data,
 			);
 		}
 

--- a/src/Field/Choices/LanguagesChoices.php
+++ b/src/Field/Choices/LanguagesChoices.php
@@ -30,7 +30,7 @@ final class LanguagesChoices implements ChoicesInterface
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{
@@ -42,7 +42,7 @@ final class LanguagesChoices implements ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed
 	{
 		return $data;

--- a/src/Field/Choices/RemoteJsonChoices.php
+++ b/src/Field/Choices/RemoteJsonChoices.php
@@ -32,7 +32,7 @@ final class RemoteJsonChoices implements ChoicesInterface
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{
@@ -44,7 +44,7 @@ final class RemoteJsonChoices implements ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed
 	{
 		return $data;

--- a/src/Field/Choices/StaticChoices.php
+++ b/src/Field/Choices/StaticChoices.php
@@ -45,7 +45,7 @@ class StaticChoices implements ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed
 	{
 		// we can just pass the value through.
@@ -56,7 +56,7 @@ class StaticChoices implements ChoicesInterface
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{

--- a/src/Field/Choices/StoryChoices.php
+++ b/src/Field/Choices/StoryChoices.php
@@ -34,7 +34,7 @@ final class StoryChoices implements ChoicesInterface
 	 * @inheritDoc
 	 */
 	public function isValidData (
-		int|string $data,
+		array|int|string $data,
 		?ComponentContext $context = null,
 	) : bool
 	{
@@ -46,7 +46,7 @@ final class StoryChoices implements ChoicesInterface
 	 */
 	public function transformData (
 		ComponentContext $context,
-		int|string $data,
+		array|int|string $data,
 	) : mixed
 	{
 		return $data;

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -2,8 +2,10 @@
 
 namespace Torr\Storyblok\Field\Definition;
 
+use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Exception\InvalidFieldConfigurationException;
@@ -67,15 +69,19 @@ final class ChoiceField extends AbstractField
 	 */
 	public function validateData (ComponentContext $context, array $contentPath, mixed $data) : void
 	{
+		$allowedValueTypeConstraints = new AtLeastOneOf([
+			new Type("string"),
+			new Type("int"),
+		]);
+
 		$context->ensureDataIsValid(
 			$contentPath,
 			$this,
 			$data,
 			[
-				new AtLeastOneOf([
-					new Type("string"),
-					new Type("int"),
-				]),
+				$this->allowMultiselect
+					? new All([new NotNull(), $allowedValueTypeConstraints])
+					: $allowedValueTypeConstraints,
 			],
 		);
 


### PR DESCRIPTION
The main issues here were:

- We were not accepting `array` values, which is required for `allowMultiSelect: true`
- The validation did not support `array<string|int>`
- The `EnumChoices` need to handle `array` values properly