### PR TITLE
Improve exception message for better tracing/debugging when hydration of a `Story` fails due to invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * (improvement) Add `StoryInterface`. 
 * (bc) Use `fullSlug` in `StoryLinkData`. 
 * (bc) Add better support for multiple story references via `StoryReferenceList`. 
+* (improvement) Improve exception message for better tracing/debugging when hydration of a `Story` fails due to invalid data.
 
 
 1.5.0

--- a/src/Story/StoryFactory.php
+++ b/src/Story/StoryFactory.php
@@ -5,6 +5,7 @@ namespace Torr\Storyblok\Story;
 use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Exception\Component\UnknownComponentKeyException;
 use Torr\Storyblok\Exception\Story\ComponentWithoutStoryException;
+use Torr\Storyblok\Exception\Story\InvalidDataException;
 use Torr\Storyblok\Exception\Story\StoryHydrationFailed;
 use Torr\Storyblok\Manager\ComponentManager;
 
@@ -60,6 +61,16 @@ final class StoryFactory
 			$story->validate($this->storyblokContext);
 
 			return $story;
+		}
+		catch (InvalidDataException $exception)
+		{
+			throw new StoryHydrationFailed(\sprintf(
+				"Failed to hydrate story (Id: '%s', Name: '%s') of type '%s' due to invalid data: %s",
+				$data["id"] ?? "n/a",
+				$data["name"] ?? "n/a",
+				$type,
+				$exception->getMessage(),
+			), previous: $exception);
 		}
 		catch (UnknownComponentKeyException $exception)
 		{


### PR DESCRIPTION
This should make it a lot easier to find the affected Stories that have invalid data. Before you could only see which type was affected, but this becomes problematic as soon as there's enough content.

### Before

<img width="786" alt="CleanShot 2023-02-13 at 15 21 13@2x" src="https://user-images.githubusercontent.com/439899/218483304-3cac8b4b-c3c6-4718-969d-68e52e9c91cd.png">


### After

<img width="792" alt="CleanShot 2023-02-13 at 15 20 43@2x" src="https://user-images.githubusercontent.com/439899/218483186-cb329aa8-c0b5-4b97-89af-32c178efa4d2.png">
