### PR TITLE
Try to use `cv` in the API client and remove the local rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.4.5
+=====
+
+* (improvement) Try to use `cv` in the API client and remove the local rate limiter.
+
+
 1.4.4
 =====
 


### PR DESCRIPTION
We could just try that and see if we have any issues.

I would keep the rate limiter in the management API