### PR TITLE
Transform links within RichText to their correct destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.0-beta.2
+============
+
+* (bug) Resolve inline `*LinkData` from within a `RichTextField` to their correct destination.
+
+
 3.0.0-beta.1
 ============
 

--- a/src/Field/Data/RichTextAssetLinkData.php
+++ b/src/Field/Data/RichTextAssetLinkData.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Data;
+
+final class RichTextAssetLinkData
+{
+	public function __construct (
+		public readonly ?string $uuid,
+		public readonly string $url,
+		public readonly ?string $anchor,
+		public readonly ?string $target,
+		public readonly ?array $custom,
+	) {}
+}

--- a/src/Field/Data/RichTextEmailLinkData.php
+++ b/src/Field/Data/RichTextEmailLinkData.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Data;
+
+final class RichTextEmailLinkData
+{
+	public function __construct (
+		public readonly ?string $uuid,
+		public readonly string $email,
+		public readonly ?string $anchor,
+		public readonly ?string $target,
+	) {}
+}

--- a/src/Field/Data/RichTextExternalLinkData.php
+++ b/src/Field/Data/RichTextExternalLinkData.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Data;
+
+final class RichTextExternalLinkData
+{
+	public function __construct (
+		public readonly ?string $uuid,
+		public readonly string $href,
+		public readonly ?string $anchor,
+		public readonly ?string $target,
+	) {}
+}

--- a/src/Field/Data/RichTextStoryLinkData.php
+++ b/src/Field/Data/RichTextStoryLinkData.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Field\Data;
+
+final class RichTextStoryLinkData
+{
+	public function __construct (
+		public readonly ?string $uuid,
+		public readonly string $fullSlug,
+		public readonly ?string $anchor,
+		public readonly ?string $target,
+	) {}
+}


### PR DESCRIPTION
This is especially useful if you’re using internal Story links as they may point to structured data/stories that may or may not have a different public URL.