### PR TITLE
Add missing `symfony/lock` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * (internal) Expose `_editable` data via `StoryMetaData::getPreviewData()`.
 * (feature) Add `ComponentPreviewData` helper to easily render component meta and preview data.
 * (improvement) Add support for setting minimum and maximum count of selected `ChoiceField` options.
+* (bug) Add missing `symfony/lock` dependency.
 
 
 3.2.2

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"psr/log": "^3.0",
 		"symfony/console": "^6.1",
 		"symfony/http-client": "^6.1",
+		"symfony/lock": "^6.2",
 		"symfony/rate-limiter": "^6.2",
 		"symfony/string": "^6.2",
 		"symfony/validator": "^6.1"


### PR DESCRIPTION
The rate limiter strategy uses it