### PR TITLE
Add option to include/exclude translations for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.6.0
+=====
+
+* (feature) Add option to exclude/include certain fields into the translation export.
+
+
 3.5.1
 =====
 

--- a/src/Field/Definition/AssetField.php
+++ b/src/Field/Definition/AssetField.php
@@ -14,6 +14,8 @@ use Torr\Storyblok\Field\FieldType;
 use Torr\Storyblok\Visitor\DataVisitorInterface;
 
 /**
+ * Can't use `no_translate` option, as it is always disabled.
+ *
  * @phpstan-type RawAssetData array{id: int|null, alt: string|null, name: string, focus: string|null, title: string|null, filename: string|null, copyright: string|null, fieldtype: string, is_external_url: bool}
  */
 final class AssetField extends AbstractField

--- a/src/Field/Definition/BloksField.php
+++ b/src/Field/Definition/BloksField.php
@@ -15,6 +15,10 @@ use Torr\Storyblok\Field\FieldType;
 use Torr\Storyblok\Manager\Sync\Filter\ResolvableComponentFilter;
 use Torr\Storyblok\Visitor\DataVisitorInterface;
 
+/**
+ * The `no_translate` option doesn't make sense here, as the field itself has no content and the content is
+ * managed by their translatable settings.
+ */
 final class BloksField extends AbstractField
 {
 	public function __construct (

--- a/src/Field/Definition/BooleanField.php
+++ b/src/Field/Definition/BooleanField.php
@@ -8,6 +8,11 @@ use Torr\Storyblok\Context\ComponentContext;
 use Torr\Storyblok\Field\FieldType;
 use Torr\Storyblok\Visitor\DataVisitorInterface;
 
+/**
+ * Checkbox field type
+ *
+ * Can't use `no_translate` option, as it is always enabled.
+ */
 final class BooleanField extends AbstractField
 {
 	/**

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -73,6 +73,9 @@ final class ChoiceField extends AbstractField
 					: $this->defaultValue,
 				"min_options" => $this->minimumNumberOfOptions,
 				"max_options" => $this->maximumNumberOfOptions,
+				// never allow to export this field to translate (as you need to know the format)
+				// also multi options are never translatable in Storyblok
+				"no_translate" => true,
 			],
 		);
 	}

--- a/src/Field/Definition/DateTimeField.php
+++ b/src/Field/Definition/DateTimeField.php
@@ -34,6 +34,8 @@ final class DateTimeField extends AbstractField
 			parent::toManagementApiData(),
 			[
 				"disable_time" => !$this->withTimeSelection,
+				// never allow to export this field to translate (as it would need to be a perfect format match)
+				"no_translate" => true,
 			],
 		);
 	}

--- a/src/Field/Definition/LinkField.php
+++ b/src/Field/Definition/LinkField.php
@@ -17,6 +17,9 @@ use Torr\Storyblok\Field\FieldType;
 use Torr\Storyblok\Manager\Sync\Filter\ResolvableComponentFilter;
 use Torr\Storyblok\Visitor\DataVisitorInterface;
 
+/**
+ * Can't use `no_translate` option, as it is always disabled.
+ */
 final class LinkField extends AbstractField
 {
 	/**

--- a/src/Field/Definition/MarkdownField.php
+++ b/src/Field/Definition/MarkdownField.php
@@ -19,6 +19,7 @@ final class MarkdownField extends AbstractField
 		private readonly bool $hasRichMarkdown = true,
 		private readonly ?int $maxLength = null,
 		private readonly bool $isRightToLeft = false,
+		private readonly bool $exportTranslation = true,
 	)
 	{
 		parent::__construct($label, $defaultValue);
@@ -43,6 +44,7 @@ final class MarkdownField extends AbstractField
 				"rich_markdown" => $this->hasRichMarkdown,
 				"rtl" => $this->isRightToLeft,
 				"max_length" => $this->maxLength,
+				"no_translate" => !$this->exportTranslation,
 			],
 		);
 	}

--- a/src/Field/Definition/NumberField.php
+++ b/src/Field/Definition/NumberField.php
@@ -14,7 +14,11 @@ final class NumberField extends AbstractField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct (string $label, int|float|null $defaultValue = null)
+	public function __construct (
+		string $label,
+		int|float|null $defaultValue = null,
+		private readonly bool $exportTranslation = true,
+	)
 	{
 		parent::__construct($label, $defaultValue);
 	}
@@ -25,6 +29,19 @@ final class NumberField extends AbstractField
 	protected function getInternalStoryblokType () : FieldType
 	{
 		return FieldType::Number;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function toManagementApiData () : array
+	{
+		return \array_replace(
+			parent::toManagementApiData(),
+			[
+				"no_translate" => !$this->exportTranslation,
+			],
+		);
 	}
 
 	/**

--- a/src/Field/Definition/RichTextField.php
+++ b/src/Field/Definition/RichTextField.php
@@ -73,6 +73,7 @@ final class RichTextField extends AbstractField
 					"restrict_components",
 				),
 				"style_options" => $formattedStyleOptions,
+				// can't set the `no_translate` field, as it is always enabled
 			],
 		);
 	}

--- a/src/Field/Definition/TableField.php
+++ b/src/Field/Definition/TableField.php
@@ -11,6 +11,11 @@ use Torr\Storyblok\Field\Data\TableData;
 use Torr\Storyblok\Field\FieldType;
 use Torr\Storyblok\Visitor\DataVisitorInterface;
 
+/**
+ * The field for managing tables.
+ *
+ * Doesn't support the `no_translate` option, it is always disabled.
+ */
 final class TableField extends AbstractField
 {
 	/**

--- a/src/Field/Definition/TextField.php
+++ b/src/Field/Definition/TextField.php
@@ -19,6 +19,7 @@ final class TextField extends AbstractField
 		private readonly bool $multiline = false,
 		private readonly ?int $maxLength = null,
 		private readonly bool $isRightToLeft = false,
+		private readonly bool $exportTranslation = true,
 	)
 	{
 		parent::__construct($label, $defaultValue);
@@ -44,6 +45,7 @@ final class TextField extends AbstractField
 			[
 				"rtl" => $this->isRightToLeft,
 				"max_length" => $this->maxLength,
+				"no_translate" => !$this->exportTranslation,
 			],
 		);
 	}


### PR DESCRIPTION
And yes, we can set some of these settings, even if the Storyblok UI doesn't have the necessary controls. I tested them all myself.