### PR TITLE
add links fetching and use them in StoryblokIdSlugMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.11.0
+======
+
+* (feature) Add fetching links in `ContentApi`.
+* (improvement) Use in `StoryblokIdSlugMapper` the links data from Storyblok instead of stories.
+
+
 3.10.2
 ======
 

--- a/src/Api/ContentApi.php
+++ b/src/Api/ContentApi.php
@@ -472,10 +472,11 @@ final class ContentApi implements ResetInterface
 		ReleaseVersion $version = ReleaseVersion::PUBLISHED,
 	) : array
 	{
-		// force per_page to the maximum to minimize pagination
-		$query["per_page"] = 1000;
-		$query["version"] = $version->value;
-		$query["cv"] = $this->getSpaceInfo()->getCacheVersion();
+		$query = [
+			// force per_page to the maximum to minimize pagination
+			"per_page" => 1000,
+			"version" => $version->value,
+		];
 
 		$result = [];
 		$page = 1;

--- a/src/Api/Data/StoryblokLink.php
+++ b/src/Api/Data/StoryblokLink.php
@@ -2,11 +2,11 @@
 
 namespace Torr\Storyblok\Api\Data;
 
-final class StoryblokLink
+final readonly class StoryblokLink
 {
-	private int $id;
-	private string $uuid;
-	private string $slug;
+	public int $id;
+	public string $uuid;
+	public string $slug;
 
 	/**
 	 */
@@ -15,26 +15,5 @@ final class StoryblokLink
 		$this->id = $data["id"];
 		$this->uuid = $data["uuid"];
 		$this->slug = $data["slug"];
-	}
-
-	/**
-	 */
-	public function getId () : int
-	{
-		return $this->id;
-	}
-
-	/**
-	 */
-	public function getUuid () : string
-	{
-		return $this->uuid;
-	}
-
-	/**
-	 */
-	public function getSlug () : string
-	{
-		return $this->slug;
 	}
 }

--- a/src/Api/Data/StoryblokLink.php
+++ b/src/Api/Data/StoryblokLink.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Api\Data;
+
+final class StoryblokLink
+{
+	private int $id;
+	private string $uuid;
+	private string $slug;
+
+	/**
+	 */
+	public function __construct (array $data)
+	{
+		$this->id = $data["id"];
+		$this->uuid = $data["uuid"];
+		$this->slug = $data["slug"];
+	}
+
+	/**
+	 */
+	public function getId () : int
+	{
+		return $this->id;
+	}
+
+	/**
+	 */
+	public function getUuid () : string
+	{
+		return $this->uuid;
+	}
+
+	/**
+	 */
+	public function getSlug () : string
+	{
+		return $this->slug;
+	}
+}

--- a/src/Api/Transformer/StoryblokIdSlugMapper.php
+++ b/src/Api/Transformer/StoryblokIdSlugMapper.php
@@ -44,8 +44,8 @@ final class StoryblokIdSlugMapper implements ResetInterface
 		foreach ($this->contentApi->fetchAllLinks() as $story)
 		{
 			// we have no overlap between the formats, so we can combine them into a single map
-			$map[$story->getUuid()] = $story->getSlug();
-			$map[$story->getId()] = $story->getSlug();
+			$map[$story->uuid] = $story->slug;
+			$map[$story->id] = $story->slug;
 		}
 
 		return $map;

--- a/src/Api/Transformer/StoryblokIdSlugMapper.php
+++ b/src/Api/Transformer/StoryblokIdSlugMapper.php
@@ -41,11 +41,11 @@ final class StoryblokIdSlugMapper implements ResetInterface
 	{
 		$map = [];
 
-		foreach ($this->contentApi->fetchAllStories("*") as $story)
+		foreach ($this->contentApi->fetchAllLinks() as $story)
 		{
 			// we have no overlap between the formats, so we can combine them into a single map
-			$map[$story->getUuid()] = $story->getFullSlug();
-			$map[$story->getMetaData()->getId()] = $story->getFullSlug();
+			$map[$story->getUuid()] = $story->getSlug();
+			$map[$story->getId()] = $story->getSlug();
 		}
 
 		return $map;


### PR DESCRIPTION
The use of links in `StoryblokIdSlugMapper` improves performance when there are many stories in the space, as this means we don't hydrate the stories.