### PR TITLE
Don't crash hard when RichText Links don't contain optional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.14.1
+======
+
+* (bug) Don't crash hard when RichText Links don't contain optional properties.
+
+
 3.14.0
 ======
 

--- a/src/RichText/LinkMarksRichTextTransformer.php
+++ b/src/RichText/LinkMarksRichTextTransformer.php
@@ -29,14 +29,14 @@ final class LinkMarksRichTextTransformer extends RichTextTransformer
 	 */
 	protected function transformData (array $data) : mixed
 	{
-		$uuid = $this->normalizeOptionalString($data["uuid"]);
+		$uuid = $this->normalizeOptionalString($data["uuid"] ?? null);
 
 		if ("story" === $data["linktype"])
 		{
 			// we have the cached_url in the data here, but we can't rely on it, as it might be out of date
 			return new RichTextStoryLinkData(
 				uuid: $uuid,
-				anchor: $data["anchor"],
+				anchor: $data["anchor"] ?? null,
 				target: $data["target"],
 			);
 		}
@@ -49,7 +49,7 @@ final class LinkMarksRichTextTransformer extends RichTextTransformer
 				? new RichTextEmailLinkData(
 					uuid: $uuid,
 					email: $email,
-					anchor: $data["anchor"],
+					anchor: $data["anchor"] ?? null,
 					target: $data["target"],
 				)
 				: null;
@@ -67,7 +67,7 @@ final class LinkMarksRichTextTransformer extends RichTextTransformer
 			return new RichTextAssetLinkData(
 				uuid: $uuid,
 				url: $url,
-				anchor: $data["anchor"],
+				anchor: $data["anchor"] ?? null,
 				target: $data["target"],
 				custom: $data["custom"] ?? null,
 			);
@@ -80,7 +80,7 @@ final class LinkMarksRichTextTransformer extends RichTextTransformer
 			? new RichTextExternalLinkData(
 				uuid: $uuid,
 				href: $href,
-				anchor: $data["anchor"],
+				anchor: $data["anchor"] ?? null,
 				target: $data["target"],
 			)
 			: null;


### PR DESCRIPTION
This can happen when the RichText has been transformed, but properties with `null` values have been omitted when transforming back into JSON.