### PR TITLE
Allow trailing slashes in webhook URL to not affect verification process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ======
 
 * (improvement) Improve type declarations.
+* (improvement) Allow trailing slashes in webhook URL to not affect verification process.
 
 
 3.17.0

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,6 +1,8 @@
 storyblok.webhook:
     path: /webhook/{urlSecret}
     controller: Torr\Storyblok\Webhook\Controller\WebhookController::webhook
+    requirements:
+        urlSecret: .*?
     defaults:
         urlSecret: ~
 

--- a/src/Webhook/Controller/WebhookController.php
+++ b/src/Webhook/Controller/WebhookController.php
@@ -26,6 +26,9 @@ final class WebhookController extends AbstractController
 		?string $urlSecret,
 	) : JsonResponse
 	{
+		// Trailing slashes at the end of the URL will cause the URL secret to contain an empty string. We're normalizing here.
+		$urlSecret = $urlSecret ?: null;
+
 		$isValidSignature = $requestValidator->isValidRequest($request, $urlSecret);
 
 		if (!$isValidSignature || !$request->isMethod("POST"))


### PR DESCRIPTION
This change prevents any accidental trailing slashes to affect the verification process by throwing an error.