### PR TITLE
Fix Choice Field Storyblok Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.19.2
+======
+
+* (bug) Send strings instead of integers to Storyblok for ChoiceField minimum and maximum option settings
+
+
 3.19.1
 ======
 

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -72,8 +72,8 @@ final class ChoiceField extends AbstractField
 				"default_value" => $this->defaultValue instanceof \BackedEnum
 					? $this->defaultValue->value
 					: $this->defaultValue,
-				"min_options" => $this->minimumNumberOfOptions,
-				"max_options" => $this->maximumNumberOfOptions,
+				"min_options" => is_int($this->minimumNumberOfOptions) ? "{$this->minimumNumberOfOptions}" : null,
+				"max_options" => is_int($this->minimumNumberOfOptions) ? "{$this->maximumNumberOfOptions}" : null,
 				// never allow to export this field to translate (as you need to know the format)
 				// also multi options are never translatable in Storyblok
 				"no_translate" => true,

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -72,8 +72,8 @@ final class ChoiceField extends AbstractField
 				"default_value" => $this->defaultValue instanceof \BackedEnum
 					? $this->defaultValue->value
 					: $this->defaultValue,
-				"min_options" => is_int($this->minimumNumberOfOptions) ? "{$this->minimumNumberOfOptions}" : null,
-				"max_options" => is_int($this->minimumNumberOfOptions) ? "{$this->maximumNumberOfOptions}" : null,
+				"min_options" => \is_int($this->minimumNumberOfOptions) ? "{$this->minimumNumberOfOptions}" : null,
+				"max_options" => \is_int($this->minimumNumberOfOptions) ? "{$this->maximumNumberOfOptions}" : null,
 				// never allow to export this field to translate (as you need to know the format)
 				// also multi options are never translatable in Storyblok
 				"no_translate" => true,

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -73,11 +73,11 @@ final class ChoiceField extends AbstractField
 					? $this->defaultValue->value
 					: $this->defaultValue,
 				// we need to provide the min_options and max_options as string, otherwise the validation
-				// of the number of choices won't work when saving an element
+				// of the number of choices won't work in Storyblok when saving an element
 				"min_options" => null !== $this->minimumNumberOfOptions
 					? (string) $this->minimumNumberOfOptions
 					: null,
-				"max_options" => null !== $this->minimumNumberOfOptions
+				"max_options" => null !== $this->maximumNumberOfOptions
 					? (string) $this->maximumNumberOfOptions
 					: null,
 				// never allow to export this field to translate (as you need to know the format)

--- a/src/Field/Definition/ChoiceField.php
+++ b/src/Field/Definition/ChoiceField.php
@@ -72,8 +72,14 @@ final class ChoiceField extends AbstractField
 				"default_value" => $this->defaultValue instanceof \BackedEnum
 					? $this->defaultValue->value
 					: $this->defaultValue,
-				"min_options" => \is_int($this->minimumNumberOfOptions) ? "{$this->minimumNumberOfOptions}" : null,
-				"max_options" => \is_int($this->minimumNumberOfOptions) ? "{$this->maximumNumberOfOptions}" : null,
+				// we need to provide the min_options and max_options as string, otherwise the validation
+				// of the number of choices won't work when saving an element
+				"min_options" => null !== $this->minimumNumberOfOptions
+					? (string) $this->minimumNumberOfOptions
+					: null,
+				"max_options" => null !== $this->minimumNumberOfOptions
+					? (string) $this->maximumNumberOfOptions
+					: null,
 				// never allow to export this field to translate (as you need to know the format)
 				// also multi options are never translatable in Storyblok
 				"no_translate" => true,


### PR DESCRIPTION
Send strings instead of integers to Storyblok for ChoiceField minimum and maximum option settings