### PR TITLE
Parse `DateTimeField`s as UTC date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 3.21.3
 ======
 
+* (bug) Parse `DateTimeField`s as UTC date.
+
+
+3.21.3
+======
+
 * (bug) Properly support '0' in `decimals` and `minValue` option for `NumberField`
 
 

--- a/src/Field/Definition/DateTimeField.php
+++ b/src/Field/Definition/DateTimeField.php
@@ -11,7 +11,7 @@ use Torr\Storyblok\Visitor\DataVisitorInterface;
 
 final class DateTimeField extends AbstractField
 {
-	private const DATE_TIME_FORMAT = "Y-m-d H:i";
+	private const string DATE_TIME_FORMAT = "Y-m-d H:i";
 
 	/**
 	 * @inheritDoc
@@ -28,6 +28,7 @@ final class DateTimeField extends AbstractField
 	/**
 	 * @inheritDoc
 	 */
+	#[\Override]
 	protected function toManagementApiData () : array
 	{
 		return array_replace(
@@ -43,6 +44,7 @@ final class DateTimeField extends AbstractField
 	/**
 	 * @inheritDoc
 	 */
+	#[\Override]
 	protected function getInternalStoryblokType () : FieldType
 	{
 		return FieldType::DateTime;
@@ -51,6 +53,7 @@ final class DateTimeField extends AbstractField
 	/**
 	 * @inheritDoc
 	 */
+	#[\Override]
 	public function validateData (ComponentContext $context, array $contentPath, mixed $data, array $fullData) : void
 	{
 		$context->ensureDataIsValid(
@@ -68,6 +71,7 @@ final class DateTimeField extends AbstractField
 	/**
 	 * @inheritDoc
 	 */
+	#[\Override]
 	public function transformData (
 		mixed $data,
 		ComponentContext $context,
@@ -81,7 +85,7 @@ final class DateTimeField extends AbstractField
 		$data = $context->normalizeOptionalString($data);
 
 		$transformed = null !== $data
-			? \DateTimeImmutable::createFromFormat(self::DATE_TIME_FORMAT, $data)
+			? \DateTimeImmutable::createFromFormat(self::DATE_TIME_FORMAT, $data, new \DateTimeZone("UTC"))
 			: null;
 
 		if (false === $transformed)


### PR DESCRIPTION
This is necessary as Storyblok is providing the date now as UTC, while also explicitly displaying the user’s timezone in their UI.

Either, this has been a silent breaking change, or we were doing it wrong for a very long time and never really noticed.

<img width="373" height="472" alt="image" src="https://github.com/user-attachments/assets/5f1afd6c-9de3-43b6-bc45-5268533f64b5" />
<img width="503" height="287" alt="image" src="https://github.com/user-attachments/assets/98988add-44a0-45ff-bcb8-9f36c3ca3538" />