### PR TITLE
Implement app deploy hook to sync definitions

### DIFF
--- a/src/Command/SyncDefinitionsCommand.php
+++ b/src/Command/SyncDefinitionsCommand.php
@@ -87,7 +87,7 @@ final class SyncDefinitionsCommand extends Command
 	/**
 	 *
 	 */
-	private function syncComponents (
+	public function syncComponents (
 		TorrStyle $io,
 		bool $sync,
 		AbstractStoryblokAdapter $adapter,

--- a/src/Config/StoryblokBundleSettings.php
+++ b/src/Config/StoryblokBundleSettings.php
@@ -10,7 +10,7 @@ readonly class StoryblokBundleSettings
 	/**
 	 */
 	public function __construct (
-		public bool $automaticallySyncDefinitionsInStaging,
-		public bool $automaticallySyncDefinitionsInProduction,
+		public bool $syncDefinitionsOnAppDeployInStaging,
+		public bool $syncDefinitionsOnAppDeployInProduction,
 	) {}
 }

--- a/src/Config/StoryblokBundleSettings.php
+++ b/src/Config/StoryblokBundleSettings.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Config;
+
+/**
+ * @final
+ */
+readonly class StoryblokBundleSettings
+{
+	/**
+	 */
+	public function __construct (
+		public bool $automaticallySyncDefinitionsInStaging,
+		public bool $automaticallySyncDefinitionsInProduction,
+	) {}
+}

--- a/src/DependencyInjection/StoryblokBundleConfiguration.php
+++ b/src/DependencyInjection/StoryblokBundleConfiguration.php
@@ -20,7 +20,7 @@ readonly class StoryblokBundleConfiguration implements ConfigurationInterface
 
 		$treeBuilder->getRootNode()
 			->children()
-				->arrayNode("automatically_sync_definitions")
+				->arrayNode("sync_definitions_on_app_deploy")
 					->addDefaultsIfNotSet()
 					->beforeNormalization()
 						->ifTrue(\is_bool(...))

--- a/src/DependencyInjection/StoryblokBundleConfiguration.php
+++ b/src/DependencyInjection/StoryblokBundleConfiguration.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @final
+ */
+readonly class StoryblokBundleConfiguration implements ConfigurationInterface
+{
+	/**
+	 *
+	 */
+	#[\Override]
+	public function getConfigTreeBuilder () : TreeBuilder
+	{
+		$treeBuilder = new TreeBuilder("storyblok");
+
+		$treeBuilder->getRootNode()
+			->children()
+				->arrayNode("automatically_sync_definitions")
+					->addDefaultsIfNotSet()
+					->beforeNormalization()
+						->ifTrue(\is_bool(...))
+						->then(static fn (bool $value) => [
+							"staging" => $value,
+							"production" => $value,
+						])
+					->end()
+					->children()
+						->booleanNode("staging")
+							->defaultValue(false)
+						->end()
+						->booleanNode("production")
+							->defaultValue(false)
+						->end()
+					->end()
+				->end()
+			->end();
+
+		return $treeBuilder;
+	}
+}

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -19,8 +19,8 @@ final class StoryblokBundleExtension extends BundleExtension implements PrependE
 		$config = $this->processConfiguration(new StoryblokBundleConfiguration(), $configs);
 
 		$container->getDefinition(StoryblokBundleSettings::class)
-			->setArgument('$automaticallySyncDefinitionsInStaging', $config["automatically_sync_definitions"]["staging"])
-			->setArgument('$automaticallySyncDefinitionsInProduction', $config["automatically_sync_definitions"]["production"]);
+			->setArgument('$syncDefinitionsOnAppDeployInStaging', $config["sync_definitions_on_app_deploy"]["staging"])
+			->setArgument('$syncDefinitionsOnAppDeployInProduction', $config["sync_definitions_on_app_deploy"]["production"]);
 	}
 
 	/**

--- a/src/DependencyInjection/StoryblokBundleExtension.php
+++ b/src/DependencyInjection/StoryblokBundleExtension.php
@@ -5,12 +5,28 @@ namespace Torr\Storyblok\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Torr\BundleHelpers\Bundle\BundleExtension;
+use Torr\Storyblok\Config\StoryblokBundleSettings;
 
 final class StoryblokBundleExtension extends BundleExtension implements PrependExtensionInterface
 {
 	/**
+	 */
+	#[\Override]
+	public function load (array $configs, ContainerBuilder $container) : void
+	{
+		parent::load($configs, $container);
+
+		$config = $this->processConfiguration(new StoryblokBundleConfiguration(), $configs);
+
+		$container->getDefinition(StoryblokBundleSettings::class)
+			->setArgument('$automaticallySyncDefinitionsInStaging', $config["automatically_sync_definitions"]["staging"])
+			->setArgument('$automaticallySyncDefinitionsInProduction', $config["automatically_sync_definitions"]["production"]);
+	}
+
+	/**
 	 * @inheritDoc
 	 */
+	#[\Override]
 	public function prepend (ContainerBuilder $container) : void
 	{
 		/**

--- a/src/Hosting/StoryblokAppDeployHook.php
+++ b/src/Hosting/StoryblokAppDeployHook.php
@@ -67,7 +67,7 @@ readonly class StoryblokAppDeployHook implements DeployAppHookInterface
 	private function shouldSync () : bool
 	{
 		return
-			($this->environment->isProduction() && $this->settings->automaticallySyncDefinitionsInProduction)
-			|| ($this->environment->isStaging() && $this->settings->automaticallySyncDefinitionsInStaging);
+			($this->environment->isProduction() && $this->settings->syncDefinitionsOnAppDeployInProduction)
+			|| ($this->environment->isStaging() && $this->settings->syncDefinitionsOnAppDeployInStaging);
 	}
 }

--- a/src/Hosting/StoryblokAppDeployHook.php
+++ b/src/Hosting/StoryblokAppDeployHook.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Torr\Storyblok\Hosting;
+
+use Torr\Hosting\Deployment\DeployAppHookInterface;
+use Torr\Hosting\Deployment\TaskCli;
+use Torr\Hosting\Hosting\HostingEnvironment;
+use Torr\Storyblok\Adapter\StoryblokAdapterRegistry;
+use Torr\Storyblok\Command\SyncDefinitionsCommand;
+use Torr\Storyblok\Config\StoryblokBundleSettings;
+
+/**
+ * @final
+ */
+readonly class StoryblokAppDeployHook implements DeployAppHookInterface
+{
+	/**
+	 */
+	public function __construct (
+		private HostingEnvironment $environment,
+		private StoryblokBundleSettings $settings,
+		private StoryblokAdapterRegistry $adapterRegistry,
+		private SyncDefinitionsCommand $syncDefinitionsCommand,
+	) {}
+
+	/**
+	 *
+	 */
+	#[\Override]
+	public function getLabel () : string
+	{
+		return "Storyblok Bundle: Sync Definitions";
+	}
+
+	/**
+	 *
+	 */
+	#[\Override]
+	public function runDeployApp (TaskCli $io) : void
+	{
+		if (!$this->shouldSync())
+		{
+			$io->caution(\sprintf(
+				"Sync disabled for environment '%s'",
+				$this->environment->getTier()->value,
+			));
+
+			return;
+		}
+
+		foreach ($this->adapterRegistry->getAllAdapters() as $adapter)
+		{
+			$io->section(\sprintf(
+				"Syncing adapter: %s",
+				$adapter->getDisplayName(),
+			));
+
+			$this->syncDefinitionsCommand->syncComponents($io, true, $adapter);
+		}
+
+		$io->success("All adapters synced");
+	}
+
+	/**
+	 *
+	 */
+	private function shouldSync () : bool
+	{
+		return
+			($this->environment->isProduction() && $this->settings->automaticallySyncDefinitionsInProduction)
+			|| ($this->environment->isStaging() && $this->settings->automaticallySyncDefinitionsInStaging);
+	}
+}

--- a/tests/DependencyInjection/StoryblokBundleConfigurationTest.php
+++ b/tests/DependencyInjection/StoryblokBundleConfigurationTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\Storyblok\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+use Torr\Storyblok\DependencyInjection\StoryblokBundleConfiguration;
+
+/**
+ * @internal
+ */
+final class StoryblokBundleConfigurationTest extends TestCase
+{
+	/**
+	 */
+	public function testDefaultValues () : void
+	{
+		$result = $this->process([]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => false,
+					"production" => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 */
+	public function testBooleanShorthandTrue () : void
+	{
+		$result = $this->process([
+			[
+				"automatically_sync_definitions" => true,
+			],
+		]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+					"production" => true,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 */
+	public function testBooleanShorthandFalse () : void
+	{
+		$result = $this->process([
+			[
+				"automatically_sync_definitions" => false,
+			],
+		]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => false,
+					"production" => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 */
+	public function testExplicitPerEnvironmentValues () : void
+	{
+		$result = $this->process([
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+					"production" => false,
+				],
+			],
+		]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+					"production" => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 */
+	public function testExplicitPartialValuesUseDefaultsForMissingKeys () : void
+	{
+		$result = $this->process([
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+				],
+			],
+		]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+					"production" => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * Later configs must override earlier ones, like when merging multiple config files.
+	 */
+	public function testMultipleConfigsAreMerged () : void
+	{
+		$result = $this->process([
+			[
+				"automatically_sync_definitions" => true,
+			],
+			[
+				"automatically_sync_definitions" => [
+					"production" => false,
+				],
+			],
+		]);
+
+		self::assertSame(
+			[
+				"automatically_sync_definitions" => [
+					"staging" => true,
+					"production" => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $configs
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function process (array $configs) : array
+	{
+		$processor = new Processor();
+
+		return $processor->processConfiguration(new StoryblokBundleConfiguration(), $configs);
+	}
+}

--- a/tests/DependencyInjection/StoryblokBundleConfigurationTest.php
+++ b/tests/DependencyInjection/StoryblokBundleConfigurationTest.php
@@ -19,7 +19,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => false,
 					"production" => false,
 				],
@@ -34,13 +34,13 @@ final class StoryblokBundleConfigurationTest extends TestCase
 	{
 		$result = $this->process([
 			[
-				"automatically_sync_definitions" => true,
+				"sync_definitions_on_app_deploy" => true,
 			],
 		]);
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 					"production" => true,
 				],
@@ -55,13 +55,13 @@ final class StoryblokBundleConfigurationTest extends TestCase
 	{
 		$result = $this->process([
 			[
-				"automatically_sync_definitions" => false,
+				"sync_definitions_on_app_deploy" => false,
 			],
 		]);
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => false,
 					"production" => false,
 				],
@@ -76,7 +76,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 	{
 		$result = $this->process([
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 					"production" => false,
 				],
@@ -85,7 +85,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 					"production" => false,
 				],
@@ -100,7 +100,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 	{
 		$result = $this->process([
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 				],
 			],
@@ -108,7 +108,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 					"production" => false,
 				],
@@ -124,10 +124,10 @@ final class StoryblokBundleConfigurationTest extends TestCase
 	{
 		$result = $this->process([
 			[
-				"automatically_sync_definitions" => true,
+				"sync_definitions_on_app_deploy" => true,
 			],
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"production" => false,
 				],
 			],
@@ -135,7 +135,7 @@ final class StoryblokBundleConfigurationTest extends TestCase
 
 		self::assertSame(
 			[
-				"automatically_sync_definitions" => [
+				"sync_definitions_on_app_deploy" => [
 					"staging" => true,
 					"production" => false,
 				],


### PR DESCRIPTION
The automatic sync needs to be explicitly enabled via the config:

```yaml
storyblok:
    sync_definitions_on_app_deploy:
        production: true
        staging: false
```